### PR TITLE
refactor beneficiary calculations for parts instead of percentages

### DIFF
--- a/src/lib/asset/manager-utils.ts
+++ b/src/lib/asset/manager-utils.ts
@@ -74,19 +74,29 @@ export function calculateAdditionalMoneyRequired(
 ): Record<string, number> {
   const additionalMoneyRequired: Record<string, number> = {};
 
+  // Calculate the sum of all ideal distributions
+  const totalIdealDistributions = Object.values(idealDistributions).reduce(
+    (sum, value) => sum + value,
+    0
+  );
+
+  // Calculate the total desired value based on the highest required amount
   const totalDesiredValue: number = Object.keys(idealDistributions).reduce(
     (total: number, beneficiaryName: string) => {
       const currentAmount: number = distributions?.[beneficiaryName] ?? 0;
-      const idealPercentage: number = idealDistributions[beneficiaryName] / 100;
+      const idealPercentage: number =
+        idealDistributions[beneficiaryName] / totalIdealDistributions;
       const idealAmount: number = currentAmount / idealPercentage;
       return Math.max(total, idealAmount);
     },
     0
   );
 
+  // Calculate the additional money required for each beneficiary
   Object.keys(idealDistributions).forEach((beneficiaryName: string): void => {
     const currentAmount: number = distributions?.[beneficiaryName] ?? 0;
-    const desiredPercentage: number = idealDistributions[beneficiaryName] / 100;
+    const desiredPercentage: number =
+      idealDistributions[beneficiaryName] / totalIdealDistributions;
     const idealAmount: number = totalDesiredValue * desiredPercentage;
     additionalMoneyRequired[beneficiaryName] = Math.max(
       0,


### PR DESCRIPTION
refactor beneficiary calculations such that we are no longer using div by 100, but using the sum total of beneficiary allocations. this enables us to use parts instead of percentages, and eliminates potential bugs around unallocated assets